### PR TITLE
Fix for: no viable alternative at input '\n'

### DIFF
--- a/com.typesafe.hocon.tests/src/com/typesafe/hocon/parser/ParserTest.xtend
+++ b/com.typesafe.hocon.tests/src/com/typesafe/hocon/parser/ParserTest.xtend
@@ -96,6 +96,16 @@ class ParserTest {
     ''')
   }
 
+  @Test
+  def void testLineFeed() {
+    succeeds("test {\n a = 2 \n}\n")
+  }
+  
+  @Test
+  def void testCarriageReturnLineFeed() {
+    succeeds("test {\r\n a = 2 \r\n}\r\n")
+  }
+
   private def void succeeds(String text) {
     val model = parser.parse(text)
     Assert.assertTrue("No errors expected, but errors found: " + model.eResource.errors, model.eResource.errors.empty)

--- a/com.typesafe.hocon/src/com/typesafe/config/Hocon.xtext
+++ b/com.typesafe.hocon/src/com/typesafe/config/Hocon.xtext
@@ -84,5 +84,5 @@ terminal SPACE:
 ;
 
 terminal NL:
-  '\n'+
+  ('\r'|'\n')+
 ;


### PR DESCRIPTION
Changed the `terminal NL` to take both `\n` and `\r` this appears to solve issue #8 additionally added two tests to verify different line ending possabilities
