### PR TITLE
Support concatenation of arrays

### DIFF
--- a/com.typesafe.hocon.tests/src/com/typesafe/hocon/parser/ParserTest.xtend
+++ b/com.typesafe.hocon.tests/src/com/typesafe/hocon/parser/ParserTest.xtend
@@ -82,6 +82,8 @@ class ParserTest {
           // This is a map with some nested maps and arrays within it, as well as some concatenations
           qux {
             baz: abc 123
+            biz: [element1, element2] [element3, element4]
+            buz: [prependelementtoarray] ${arrayref}
             bar: {
               baz: abcdefg
               bar: {

--- a/com.typesafe.hocon.tests/src/com/typesafe/hocon/parser/ParserTest.xtend
+++ b/com.typesafe.hocon.tests/src/com/typesafe/hocon/parser/ParserTest.xtend
@@ -118,7 +118,7 @@ class ParserTest {
 
   @Test
   def void testSubstitution() {
-    succeeds("${foo.bar} += ${akka.timeout}\n")
+    succeeds("foo.bar += ${akka.timeout}\n")
   }
 
   @Test

--- a/com.typesafe.hocon/src/com/typesafe/config/Hocon.xtext
+++ b/com.typesafe.hocon/src/com/typesafe/config/Hocon.xtext
@@ -50,7 +50,11 @@ Null:
 
 
 StringLiteral returns EString: 
-  (name = STRING | name = UNQUOTED_STRING | '${' ('?')? UNQUOTED_STRING '}')
+  (name = STRING | name = UNQUOTED_STRING | Substitution)
+;
+
+Substitution returns EString:
+  '${' ('?')? UNQUOTED_STRING '}'
 ;
 
 NumberLiteral:

--- a/com.typesafe.hocon/src/com/typesafe/config/Hocon.xtext
+++ b/com.typesafe.hocon/src/com/typesafe/config/Hocon.xtext
@@ -27,10 +27,10 @@ Member:
 ;
   
 Literal:
-  (value += SimpleLiteral)+ | Object | Array ;
+  (value += SimpleLiteral)+ | Object | (value += Array)+ ;
 
 SimpleLiteral returns EString:
-  (StringLiteral | name = Boolean | Null | NumberLiteral)
+  (StringLiteral | name = Boolean | Null | NumberLiteral | Substitution)
 ;
 
 Array:
@@ -38,7 +38,7 @@ Array:
       (values+=Literal) 
       ((',' | NL) NL* values+=Literal)*
       NL* 
-  ']') | ( '[' NL* ']' )
+  ']') | Substitution | ( '[' NL* ']' )
 ;
 
 Boolean:
@@ -50,7 +50,7 @@ Null:
 
 
 StringLiteral returns EString: 
-  (name = STRING | name = UNQUOTED_STRING | Substitution)
+  (name = STRING | name = UNQUOTED_STRING)
 ;
 
 Substitution returns EString:


### PR DESCRIPTION
We are in a situation where we want to **pre**pend an element to an array.
HOCON [does allow that](https://github.com/typesafehub/config#concatenation), however the plugin doesn't recognize the syntax :(

@dragos If you could merge that and release a new version that would be really great! We already made a custom built and use the plugin with this PR included and it works great. Thank you!